### PR TITLE
Visualize region generation affiliation and use thicker borders.

### DIFF
--- a/src/main/java/org/openjdk/shenandoah/Colors.java
+++ b/src/main/java/org/openjdk/shenandoah/Colors.java
@@ -60,12 +60,12 @@ public class Colors {
     static final Color LIVE_BORDER          = new Color(0, 100, 0);
     static final Color BORDER               = new Color(150, 150, 150);
 
-    static final Color AGE_0 = new Color(255, 175, 0);
-    static final Color AGE_1 = Color.ORANGE;
-    static final Color AGE_2 = Color.RED;
-    static final Color AGE_3 = Color.MAGENTA;
-    static final Color AGE_4 = new Color(140, 60,245);
-    static final Color AGE_5 = Color.BLUE;
+    static final Color AGE_0 = Color.LIGHT_GRAY;
+    static final Color AGE_1 = Color.YELLOW;
+    static final Color AGE_2 = Color.ORANGE;
+    static final Color AGE_3 = Color.RED;
+    static final Color AGE_4 = Color.BLUE;
+    static final Color AGE_5 = Color.BLACK;
 
     static final Color[] AGE_COLORS = {AGE_0, AGE_1, AGE_2, AGE_3, AGE_4};
 }

--- a/src/main/java/org/openjdk/shenandoah/Colors.java
+++ b/src/main/java/org/openjdk/shenandoah/Colors.java
@@ -38,6 +38,10 @@ public class Colors {
     static final Color YOUNG_TIMELINE_EVACUATING = new Color(168, 194, 86);
     static final Color YOUNG_TIMELINE_UPDATEREFS = new Color(51, 115, 87);
 
+    static final Color DEGENERATE_YOUNG  = Color.ORANGE;
+    static final Color DEGENERATE_GLOBAL = Color.MAGENTA;
+    static final Color FULL              = Color.RED;
+    
     static final Color SHARED_ALLOC           = new Color(0, 250, 250);
     static final Color SHARED_ALLOC_BORDER    = new Color(0, 191, 190);
     static final Color TLAB_ALLOC           = new Color(0, 200, 0);

--- a/src/main/java/org/openjdk/shenandoah/RegionAffiliation.java
+++ b/src/main/java/org/openjdk/shenandoah/RegionAffiliation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, Red Hat, Inc. All rights reserved.
+ * Copyright (c) 2020, Amazon.com, Inc. or its affiliates All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -24,32 +24,18 @@
  */
 package org.openjdk.shenandoah;
 
-public enum RegionState {
-    EMPTY_UNCOMMITTED,
-    EMPTY_COMMITTED,
-    REGULAR,
-    HUMONGOUS,
-    CSET,
-    PINNED,
-    TRASH,
-    PINNED_CSET,
-    PINNED_HUMONGOUS;
+public enum RegionAffiliation {
+    FREE,
+    YOUNG,
+    OLD;
 
-    static RegionState fromOrdinal(int idx) {
-        switch (idx) {
-            case 0: return EMPTY_UNCOMMITTED;
-            case 1: return EMPTY_COMMITTED;
-            case 2: return REGULAR;
-            case 3: return HUMONGOUS;
-            case 4: return HUMONGOUS;
-            case 5: return CSET;
-            case 6: return PINNED;
-            case 7: return TRASH;
-            case 8: return PINNED_CSET;
-            case 9: return PINNED_HUMONGOUS;
+    static RegionAffiliation fromOrdinal(int ordinal) {
+        switch (ordinal) {
+            case 0: return FREE;
+            case 1: return YOUNG;
+            case 2: return OLD;
             default:
-                throw new IllegalStateException("Unhandled ordinal: " + idx);
+                throw new IllegalStateException("Unhandled ordinal: " + ordinal);
         }
     }
-
 }

--- a/src/main/java/org/openjdk/shenandoah/Snapshot.java
+++ b/src/main/java/org/openjdk/shenandoah/Snapshot.java
@@ -33,6 +33,8 @@ public class Snapshot {
     private final List<RegionStat> stats;
     private final Phase phase;
     private final boolean youngActive;
+    private final boolean degenActive;
+    private final boolean fullActive;
 
     public Snapshot(long time, long regionSize, List<RegionStat> stats, int status) {
         this.time = time;
@@ -40,6 +42,8 @@ public class Snapshot {
         this.stats = stats;
 
         this.youngActive = ((status & 0x8) >> 3) == 1;
+        this.degenActive = ((status & 0x10) >> 4) == 1;
+        this.fullActive  = ((status & 0x20) >> 5) == 1;
         switch (status & 0x7) {
             case 0x0:
                 this.phase = Phase.IDLE;
@@ -65,6 +69,14 @@ public class Snapshot {
 
     public boolean isYoungActive() {
         return youngActive;
+    }
+
+    public boolean isDegenActive() {
+        return degenActive;
+    }
+
+    public boolean isFullActive() {
+        return fullActive;
     }
 
     public RegionStat get(int i) {

--- a/src/main/java/org/openjdk/shenandoah/SnapshotView.java
+++ b/src/main/java/org/openjdk/shenandoah/SnapshotView.java
@@ -36,6 +36,8 @@ public class SnapshotView {
     private final long collectionSet;
     private final long trash;
     private final boolean youngActive;
+    private final boolean degenActive;
+    private final boolean fullActive;
 
     public SnapshotView(Snapshot s) {
         time = s.time();
@@ -48,6 +50,8 @@ public class SnapshotView {
         collectionSet = s.collectionSet();
         trash = s.trash();
         youngActive = s.isYoungActive();
+        degenActive = s.isDegenActive();
+        fullActive = s.isFullActive();
     }
 
     public Phase phase() {
@@ -88,5 +92,13 @@ public class SnapshotView {
 
     public boolean isYoungActive() {
         return youngActive;
+    }
+
+    public boolean isDegenActive() {
+        return degenActive;
+    }
+
+    public boolean isFullActive() {
+        return fullActive;
     }
 }


### PR DESCRIPTION
Works only with the latest GenShen M6 prototype. Supports both vanilla modes and generational mode.