### PR TITLE
Fixing the speed up problem after pausing the visualizer

### DIFF
--- a/src/main/java/org/openjdk/shenandoah/ShenandoahVisualizer.java
+++ b/src/main/java/org/openjdk/shenandoah/ShenandoahVisualizer.java
@@ -805,6 +805,10 @@ class ShenandoahVisualizer {
                     data.controlStopwatch("STOP");
                     isPaused = true;
                 }
+            } else {
+                if (data.stopwatch.isStarted()) {
+                    data.controlStopwatch("STOP");
+                }
             }
         }
 

--- a/src/main/java/org/openjdk/shenandoah/ShenandoahVisualizer.java
+++ b/src/main/java/org/openjdk/shenandoah/ShenandoahVisualizer.java
@@ -188,10 +188,8 @@ class ShenandoahVisualizer {
         ActionListener playPauseButtonListener = new ActionListener() {
             public void actionPerformed(ActionEvent ae) {
                 if (renderRunner.playback.isPaused) {
-                    renderRunner.playback.data.controlStopwatch("START");
                     toolbarPanel.setLastActionField("Play button pressed.");
                 } else {
-                    renderRunner.playback.data.controlStopwatch("STOP");
                     toolbarPanel.setLastActionField("Pause button pressed.");
                 }
                 renderRunner.playback.isPaused = !renderRunner.playback.isPaused;
@@ -778,6 +776,9 @@ class ShenandoahVisualizer {
 
         public synchronized void run() {
             if (!isPaused) {
+                if (!data.stopwatch.isStarted()) {
+                    data.controlStopwatch("START");
+                }
                 if (endSnapshotIndex < lastSnapshots.size()) {
                     int i = Math.max(endSnapshotIndex - 1, 0);
                     long time = lastSnapshots.get(i).time();


### PR DESCRIPTION
Creating an `else` statement for the `run` method to stop the stopwatch when it is paused.