### PR TITLE
Fixing the front snapshot index not adding

### DIFF
--- a/src/main/java/org/openjdk/shenandoah/ShenandoahVisualizer.java
+++ b/src/main/java/org/openjdk/shenandoah/ShenandoahVisualizer.java
@@ -792,6 +792,9 @@ class ShenandoahVisualizer {
                         frame.repaint();
                         repaintPopups();
                     }
+                    if (endSnapshotIndex - frontSnapshotIndex > graphWidth / STEP_X) {
+                        frontSnapshotIndex++;
+                    }
                 } else {
                     Snapshot cur = data.snapshot();
                     if (!cur.equals(snapshot)) {


### PR DESCRIPTION
Fixing the graph panel won't scroll correctly once it reaches the end snapshot and try to step back and replay.